### PR TITLE
Bump bevy to 0.12

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,11 +11,11 @@ keywords = ["bevy", "spawning", "spawn"]
 categories = ["game-development"]
 
 [dependencies.bevy]
-version = "0.11"
+version = "0.12"
 default-features = false
 
 [dev-dependencies.bevy]
-version = "0.11"
+version = "0.12"
 default-features = false
 features = [
     "bevy_asset",


### PR DESCRIPTION
Luckily, no changes required.

Ran all examples locally to check for potential issues.